### PR TITLE
Correccion obligaciones especificas

### DIFF
--- a/microservices/entities_service/entity_app/application/views/numeral_update.py
+++ b/microservices/entities_service/entity_app/application/views/numeral_update.py
@@ -13,12 +13,20 @@ class UpdateNumeralStateView(APIView):
 
     def patch(self, request, numeral_id):
         """
-        Endpoint para actualizar el estado de un numeral (is_selected=True).
+        Endpoint para actualizar el estado de un numeral con is_selected dinámico.
         """
         try:
-            # Llamar al servicio para actualizar el estado
-            updated_numeral = self.service.update_numeral_state(numeral_id, is_default=True)
-            # Suponiendo que 'updated_numeral' contiene la información completa del numeral
+            # Obtener el valor de is_selected desde el cuerpo de la solicitud
+            is_selected = request.data.get("isSelected")
+            if is_selected is None:
+                return Response(
+                    {"error": "El campo 'isSelected' es requerido."},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            # Llamar al servicio para actualizar el estado usando el valor dinámico
+            updated_numeral = self.service.update_numeral_state(numeral_id, is_selected=is_selected)
+
             return Response({
                 "message": "Numeral actualizado exitosamente.",
             }, status=status.HTTP_200_OK)

--- a/microservices/entities_service/entity_app/domain/models/transparency_active.py
+++ b/microservices/entities_service/entity_app/domain/models/transparency_active.py
@@ -27,6 +27,7 @@ class Numeral(BaseModel):
     parent = models.ForeignKey(
         'self', on_delete=models.CASCADE, related_name='children', null=True, blank=True)
     is_default = models.BooleanField(default=True)
+    is_selected = models.BooleanField(default=False)
     type_transparency = models.CharField(max_length=255, choices=(
         ('A', 'Activa'), ('P', 'Pasiva'), ('C', 'Colaborativa'), ('F', 'Focalizada')), default='A')
     objects = models.Manager()

--- a/microservices/entities_service/entity_app/domain/services/numeral_service.py
+++ b/microservices/entities_service/entity_app/domain/services/numeral_service.py
@@ -42,7 +42,7 @@ class NumeralService:
     def aprove_transparency(self, id):
         return self.numeral_repository.aprove_transparency(id)
 
-    def update_numeral_state(self, numeral_id: int, is_default: bool):
+    def update_numeral_state(self, numeral_id: int, is_selected: bool):
         """
         Actualiza el estado de un numeral en la base de datos.
         """
@@ -51,5 +51,5 @@ class NumeralService:
             raise ValueError(f"El numeral con ID {numeral_id} no existe.")
 
         # Actualizar el estado
-        numeral.is_default = is_default
+        numeral.is_selected = is_selected
         return self.numeral_repository.update(numeral)


### PR DESCRIPTION
### Problema:
Cuando se envia por API el campo default hace que cambie las obligaciones especificas a generales.

### Solucion:
Crear un nuevo campo y agregar validacion dinamica para el endpoint.