### PR TITLE
feat: agregar endpoint para exportar todas las solicitudes

### DIFF
--- a/microservices/entities_service/entity_app/application/views/reports.py
+++ b/microservices/entities_service/entity_app/application/views/reports.py
@@ -154,6 +154,36 @@ class ReporteSolicitudes(APIView):
         return response
 
 
+class ReporteTodasSolicitudes(APIView):
+    permission_classes = [IsAuthenticated, HasPermission]
+    permission_required = 'view_solicityresponse'
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.solicity_service = SolicityService(SolicityImpl())
+        self.transparency_service = TransparencyActiveService(TransparencyActiveImpl())
+        self.numera_service = NumeralService(NumeralImpl())
+        self.transparency_collab = TransparencyColaborativeService(TransparencyColaborativeImpl())
+        self.transparency_focus = TransparencyFocusService(TransparencyFocalImpl())
+        
+        # Inicialización completa de ReportService
+        self.report_service = ReportService(
+            self.solicity_service,
+            self.transparency_service,
+            self.numera_service,
+            self.transparency_collab,
+            self.transparency_focus
+        )
+
+    def post(self, request):
+        year = request.data.get('year', datetime.now().year)
+        value = self.report_service.generate_all_solicities(request.user.id, year)
+
+        response = HttpResponse(value, content_type='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')
+        response['Content-Disposition'] = 'attachment; filename="TodasLasSolicitudes.xlsx"'
+        return response
+    
+
 class ReporteNoRespuestas(ListAPIView):
     permission_classes = [IsAuthenticated, HasPermission]
     serializer_class = SolicitySerializer

--- a/microservices/entities_service/entity_app/domain/services/report_service.py
+++ b/microservices/entities_service/entity_app/domain/services/report_service.py
@@ -69,6 +69,50 @@ class ReportService:
         
         return response_stream
     
+    def generate_all_solicities(self, user_id: int, year: int):
+        output_serializer_class = SolicityResponseSerializer
+
+        # Obtener las solicitudes del usuario para el año específico
+        solicity = self.solicity_service.get_entity_user_solicities(user_id)
+        solicity = solicity.filter(created_at__year=year)  # Mantén el filtro por año si es necesario
+
+        # Crear un libro de Excel
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws.title = "Todas las Solicitudes"
+
+        # Encabezados
+        headers = ['N°', 'No. SAIP', 'Fecha Envío', 'Días Transcurridos', 'Estado']
+        for col_num, column_title in enumerate(headers, 1):
+            column_letter = get_column_letter(col_num)
+            ws[f'{column_letter}1'] = column_title
+
+        # Recopilar datos
+        lista_solicity = []
+        for row_num, row_data in enumerate(solicity):
+            row_ = {
+                'index': row_num + 1,  # Índice inicia en 1
+                'no_saip': row_data.number_saip,
+                'created_at': row_data.created_at.strftime('%Y-%m-%d'),
+                'days': (datetime.now().date() - row_data.created_at.date()).days,
+                'status': row_data.status,  # Incluye el estado de la solicitud
+            }
+            lista_solicity.append(row_)
+
+        # Escribir datos en el Excel
+        for row_num, row_data in enumerate(lista_solicity, 2):  # Inicia en la fila 2
+            for col_num, (column_name, cell_value) in enumerate(row_data.items(), 1):
+                column_letter = get_column_letter(col_num)
+                ws[f'{column_letter}{row_num}'] = cell_value
+
+        # Guardar el archivo en un stream
+        from io import BytesIO
+        response_stream = BytesIO()
+        wb.save(response_stream)
+        response_stream.seek(0)
+
+        return response_stream
+    
     
     def generate_solicities_response(self,user_id:int,year:int):
         output_serializer_class = SolicityResponseSerializer

--- a/microservices/entities_service/entity_app/urls.py
+++ b/microservices/entities_service/entity_app/urls.py
@@ -22,7 +22,7 @@ from entity_app.application.views.focus_transparency import CreateTransparencyFo
 from entity_app.application.views.template_file import TemplateFileValidate
 from entity_app.application.views.transparency_active import TransparencyActivePublicListView, TransparencyActiveToApproveListView
 
-from entity_app.application.views.reports import ArchivosSubidos, ReporteArchivos, ReporteRespuestas, ReporteNoRespuestas, ReporteSolicitudes
+from entity_app.application.views.reports import ArchivosSubidos, ReporteArchivos, ReporteRespuestas, ReporteNoRespuestas, ReporteSolicitudes, ReporteTodasSolicitudes
 from entity_app.application.views.public import MonthForTransparency
 from entity_app.application.views.numeral_update import UpdateNumeralStateView
 
@@ -169,4 +169,9 @@ urlpatterns = [
     # ReporteSolicitudes
     path('reports/download/reporte-solicitudes',
          ReporteSolicitudes.as_view(), name='reports-view-reporte-solicitudes'),
+
+     # ReporteAllSolicitudes
+     path('reports/download/reporte-todas-solicitudes', 
+     ReporteTodasSolicitudes.as_view(), name='reports-view-reporte-todas-solicitudes'),
+
 ]


### PR DESCRIPTION
### Features:
- Se implementó un nuevo endpoint `/reports/download/reporte-todas-solicitudes`
  que permite descargar un reporte con todas las solicitudes, 
  independientemente de su estado.
- Se añadió el método `generate_all_solicities` en el servicio de reportes.
- Corrección de inicialización en `ReportService` con todos los servicios necesarios.

Esto cumple con el requerimiento de exportar todos los datos en un reporte.