### PR TITLE
FIX: cambiar el numero de dias en prorroga

### DIFF
--- a/microservices/entities_service/entity_app/utils/functions.py
+++ b/microservices/entities_service/entity_app/utils/functions.py
@@ -14,7 +14,7 @@ def get_timedelta_for_expired():
 
 
 def get_time_prorroga():
-    return timedelta(days=10)
+    return timedelta(days=15)
 
 
 def get_day_for_publish():


### PR DESCRIPTION
Cambiamos el numero de dias para que se guarden para fecha de expiracion el dia 15.
### Ejemplo: 
![test](https://github.com/user-attachments/assets/d92172b4-40dc-4880-8b9f-03f0c37d7ea9)
Se crea la solicitud y debe caducar el dia 28 porque se crea el dia 18. 
Cuando se activa la prorroga se cambia la fecha al dia 02 del mes siguiente por los 15 dias de prorroga.
