### PR TITLE
Fix: Error en fechas naive aware

### DIFF
--- a/microservices/entities_service/entity_app/domain/services/report_service.py
+++ b/microservices/entities_service/entity_app/domain/services/report_service.py
@@ -2,6 +2,7 @@
 from openpyxl.utils import get_column_letter
 import openpyxl
 from datetime import datetime
+from django.utils import timezone
 
 from entity_app.domain.models.solicity import Status
 from entity_app.adapters.serializers import NumeralResponseSerializer, SolicityResponseSerializer
@@ -190,7 +191,7 @@ class ReportService:
             elif row_data.status in ["PRORROGA", "NO_RESPONSED", "INSISTENCY_NO_RESPONSED"]:
                 end_date = row_data.expiry_date
             else:
-                end_date = datetime.now()  # Fecha actual para estados no especificados
+                end_date = timezone.now()  # Fecha actual para estados no especificados
 
             # Asegurarse de que las fechas sean válidas
             if row_data.created_at and end_date:


### PR DESCRIPTION
El error se encuentra en la siguiente parte:

```
diff_in_seconds = (end_date - row_data.created_at).total_seconds()
```

Aquí end_date puede ser naive (si es `datetime.now()`) o aware (si proviene de `row_data.expiry_date` o `row_data.updated_at`).
Mientras que `row_data.created_at` probablemente es `aware`, ya que proviene de la base de datos de Django.